### PR TITLE
Fix missing imports and over long `sleep` when using `-b` option

### DIFF
--- a/iseult.py
+++ b/iseult.py
@@ -48,6 +48,7 @@ if __name__ == '__main__':
         runMe(cmd_args)
     else:
         if cmd_args.wait:
+            import subprocess, time
             slurm_num = sys.stdin.read().split[-1]
             print(slurm_num)
             num = 0
@@ -56,7 +57,7 @@ if __name__ == '__main__':
                     slurm_queue = subprocess.check_output(["squeue"])
                     if slurm_queue.find(slurm_num) != -1:
                         num += 1
-                        time.sleep(3E5)
+                        time.sleep(300)
 
         from oengus import runMe
         print(cmd_args.name, cmd_args.O)

--- a/iseult.py
+++ b/iseult.py
@@ -3,6 +3,7 @@
 if __name__ == '__main__':
 
     import argparse
+    import warnings
 
     parser = argparse.ArgumentParser(description='Plotting program for Tristan-MP files.')
 
@@ -47,6 +48,7 @@ if __name__ == '__main__':
         from main_app import runMe
         runMe(cmd_args)
     else:
+        warnings.warn('The `-b` option has not been verified to be fully functional.', RuntimeWarning)
         if cmd_args.wait:
             import subprocess, time
             slurm_num = sys.stdin.read().split[-1]


### PR DESCRIPTION
The code that handled running Iseult when the `-b` flag was used was missing two imports and had a sleep statement that slept for ~83 hours instead of the intended 5 minutes. I fixed both those issues and added a warning that the `-b` option is rarely used and might not be functioning as intended.